### PR TITLE
fix for October Update

### DIFF
--- a/ComponentExtractors.cs
+++ b/ComponentExtractors.cs
@@ -803,7 +803,6 @@
             EntityDebug.RegisterExtractor<ProjectM.Network.RandomizeCustomization2DebugEvent>();
             EntityDebug.RegisterExtractor<ProjectM.Network.ChangeHealthDebugEvent>();
             EntityDebug.RegisterExtractor<ProjectM.Network.ChangeBloodDebugEvent>();
-            EntityDebug.RegisterExtractor<ProjectM.Network.ConsumeBloodDebugEvent>();
             EntityDebug.RegisterExtractor<ProjectM.Network.ChangeVBloodDebugEvent>();
             EntityDebug.RegisterExtractor<ProjectM.Network.TeleportToVBloodDebugEvent>();
             EntityDebug.RegisterExtractor<ProjectM.Network.UnlockAllVBloodAbilities>();

--- a/ComponentExtractors.tt
+++ b/ComponentExtractors.tt
@@ -834,7 +834,6 @@ namespace KindredExtract
     "ProjectM.Network.RandomizeCustomization2DebugEvent",
     "ProjectM.Network.ChangeHealthDebugEvent",
     "ProjectM.Network.ChangeBloodDebugEvent",
-    "ProjectM.Network.ConsumeBloodDebugEvent",
     "ProjectM.Network.ChangeVBloodDebugEvent",
     "ProjectM.Network.TeleportToVBloodDebugEvent",
     "ProjectM.Network.UnlockAllVBloodAbilities",


### PR DESCRIPTION
Removed references to ConsumeBloodDebugEvent which has been removed from the game, and were preventing extractors from initializing.